### PR TITLE
Make blevm mockable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -983,7 +983,12 @@ name = "blevm-common"
 version = "0.1.0"
 dependencies = [
  "bincode",
+ "celestia-types",
+ "nmt-rs",
+ "rsp-client-executor",
  "serde",
+ "tendermint",
+ "tendermint-proto",
 ]
 
 [[package]]

--- a/blevm/src/main.rs
+++ b/blevm/src/main.rs
@@ -9,7 +9,7 @@ use celestia_types::{
 use nmt_rs::simple_merkle::tree::MerkleHash;
 use std::io::Read;
 //use nmt_rs::{simple_merkle::proof::Proof, TmSha2Hasher};
-use blevm_common::BlevmOutput;
+use blevm_common::{BlevmInput, BlevmOutput};
 use nmt_rs::{simple_merkle::proof::Proof, NamespacedHash, TmSha2Hasher};
 use reth_primitives::Block;
 use rsp_client_executor::{
@@ -21,26 +21,20 @@ use tendermint_proto::Protobuf;
 
 pub fn main() {
     println!("cycle-tracker-start: cloning and deserializing inputs");
-    let input: ClientExecutorInput = sp1_zkvm::io::read();
-    let namespace: Namespace = sp1_zkvm::io::read();
-    let celestia_header_hash: TmHash = sp1_zkvm::io::read();
-    let data_hash_bytes: Vec<u8> = sp1_zkvm::io::read_vec();
-    let data_hash: TmHash = TmHash::decode_vec(&data_hash_bytes).unwrap();
-    let proof_data_hash_to_celestia_hash: Proof<TmSha2Hasher> = sp1_zkvm::io::read();
-    let row_root_multiproof: Proof<TmSha2Hasher> = sp1_zkvm::io::read();
-    let nmt_multiproofs: Vec<NamespaceProof> = sp1_zkvm::io::read();
-    let row_roots: Vec<NamespacedHash<29>> = sp1_zkvm::io::read();
 
-    let block = input.current_block.clone();
+    let blevm_input: BlevmInput = sp1_zkvm::io::read();
+
+    let block = blevm_input.input.current_block.clone();
     println!("cycle-tracker-end: cloning and deserializing inputs");
 
     // Verify that the data root goes into the Celestia block hash
     println!("cycle-tracker-start: verify data root");
     let hasher = TmSha2Hasher {};
-    proof_data_hash_to_celestia_hash
+    blevm_input
+        .proof_data_hash_to_celestia_hash
         .verify_range(
-            celestia_header_hash.as_bytes().try_into().unwrap(),
-            &[hasher.hash_leaf(&data_hash_bytes)],
+            &blevm_input.data_hash.clone().try_into().unwrap(),
+            &[hasher.hash_leaf(&blevm_input.data_hash.clone())],
         )
         .unwrap();
     println!("cycle-tracker-end: verify data root");
@@ -50,7 +44,7 @@ pub fn main() {
     println!("cycle-tracker-end: serializing EVM block");
 
     println!("cycle-tracker-start: creating Blob");
-    let blob = Blob::new(namespace, block_bytes, AppVersion::V3).unwrap();
+    let blob = Blob::new(blevm_input.namespace, block_bytes, AppVersion::V3).unwrap();
     println!("{}", hex::encode(blob.commitment.0));
     println!("cycle-tracker-end: creating Blob");
 
@@ -61,11 +55,15 @@ pub fn main() {
     // Verify NMT multiproofs of blob shares into row roots
     println!("cycle-tracker-start: verify NMT multiproofs of blob shares into row roots");
     let mut start = 0;
-    for i in 0..nmt_multiproofs.len() {
-        let proof = &nmt_multiproofs[i];
+    for i in 0..blevm_input.nmt_multiproofs.len() {
+        let proof = &blevm_input.nmt_multiproofs[i];
         let end = start + (proof.end_idx() as usize - proof.start_idx() as usize);
         proof
-            .verify_range(&row_roots[i], &shares[start..end], namespace.into())
+            .verify_range(
+                &blevm_input.row_roots[i],
+                &shares[start..end],
+                blevm_input.namespace.into(),
+            )
             .expect("NMT multiproof into row root failed verification"); // Panicking should prevent an invalid proof from being generated
         start = end;
     }
@@ -74,12 +72,13 @@ pub fn main() {
     // Verify row root inclusion into data root
     println!("cycle-tracker-start: verify row root inclusion into data root");
     let tm_hasher = TmSha2Hasher {};
-    let blob_row_root_hashes: Vec<[u8; 32]> = row_roots
+    let blob_row_root_hashes: Vec<[u8; 32]> = blevm_input
+        .row_roots
         .iter()
         .map(|root| tm_hasher.hash_leaf(&root.to_array()))
         .collect();
-    let result = row_root_multiproof.verify_range(
-        data_hash.as_bytes().try_into().unwrap(),
+    let result = blevm_input.row_root_multiproof.verify_range(
+        &blevm_input.data_hash.try_into().unwrap(),
         &blob_row_root_hashes,
     );
     println!("cycle-tracker-end: verify row root inclusion into data root");
@@ -87,7 +86,9 @@ pub fn main() {
     // Execute the block
     println!("cycle-tracker-start: executing EVM block");
     let executor = ClientExecutor;
-    let header = executor.execute::<EthereumVariant>(input).unwrap(); // panicking should prevent a proof of invalid execution from being generated
+    let header = executor
+        .execute::<EthereumVariant>(blevm_input.input)
+        .unwrap(); // panicking should prevent a proof of invalid execution from being generated
     println!("cycle-tracker-end: executing EVM block");
 
     // Commit the header hash
@@ -103,7 +104,7 @@ pub fn main() {
         gas_used: header.gas_used,
         beneficiary: header.beneficiary.into(),
         state_root: header.state_root.into(),
-        celestia_header_hash: celestia_header_hash.as_bytes().try_into().unwrap(),
+        celestia_header_hash: blevm_input.celestia_header_hash.try_into().unwrap(),
     };
     sp1_zkvm::io::commit(&output);
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -6,3 +6,8 @@ edition = "2021"
 [dependencies]
 serde = { workspace = true }
 bincode = { workspace = true }
+celestia-types = { workspace = true }
+tendermint = {workspace=true}
+tendermint-proto = {workspace=true}
+rsp-client-executor = {workspace=true}
+nmt-rs = "*"

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -11,8 +11,8 @@ use tendermint::Hash as TmHash;
 pub struct BlevmInput {
     pub input: ClientExecutorInput,
     pub namespace: Namespace,
-    pub celestia_header_hash: TmHash,
-    pub data_hash: TmHash,
+    pub celestia_header_hash: Vec<u8>, // changed from TmHash due to serialization issues
+    pub data_hash: Vec<u8>,            // changed from TmHash
     pub proof_data_hash_to_celestia_hash: Proof<TmSha2Hasher>,
     pub row_root_multiproof: Proof<TmSha2Hasher>,
     pub nmt_multiproofs: Vec<NamespaceProof>,

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,4 +1,23 @@
+use celestia_types::{nmt::Namespace, nmt::NamespaceProof, AppVersion, Blob};
+use nmt_rs::{simple_merkle::proof::Proof, NamespacedHash, TmSha2Hasher};
+use rsp_client_executor::{
+    io::ClientExecutorInput, ChainVariant, ClientExecutor, EthereumVariant, CHAIN_ID_ETH_MAINNET,
+    CHAIN_ID_LINEA_MAINNET, CHAIN_ID_OP_MAINNET,
+};
 use serde::{Deserialize, Serialize};
+use tendermint::Hash as TmHash;
+
+#[derive(Serialize, Deserialize)]
+pub struct BlevmInput {
+    pub input: ClientExecutorInput,
+    pub namespace: Namespace,
+    pub celestia_header_hash: TmHash,
+    pub data_hash: TmHash,
+    pub proof_data_hash_to_celestia_hash: Proof<TmSha2Hasher>,
+    pub row_root_multiproof: Proof<TmSha2Hasher>,
+    pub nmt_multiproofs: Vec<NamespaceProof>,
+    pub row_roots: Vec<NamespacedHash<29>>,
+}
 
 #[derive(Serialize, Deserialize)]
 pub struct BlevmOutput {

--- a/script/Cargo.toml
+++ b/script/Cargo.toml
@@ -9,6 +9,7 @@ name = "blevm"
 path = "src/bin/main.rs"
 
 [dependencies]
+blevm-common = { path = "../common" }
 sp1-sdk = { workspace=true }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 serde = { version = "1.0.200", default-features = false, features = ["derive"] }

--- a/script/build.rs
+++ b/script/build.rs
@@ -1,5 +1,5 @@
 use sp1_helper::build_program_with_args;
 
 fn main() {
-    build_program_with_args("../blevm", Default::default())
+    //build_program_with_args("../blevm", Default::default())
 }


### PR DESCRIPTION
# Overview
For blevm to be properly mockable, all the output fields need to be present in the input so the mock can simply connect them and skip validation